### PR TITLE
Pin tfjs-node version

### DIFF
--- a/node-red-contrib-tfjs-object-detection/package.json
+++ b/node-red-contrib-tfjs-object-detection/package.json
@@ -3,12 +3,12 @@
     "version": "0.0.1",
     "description": "TensorFlow.js Object Detection model Node-RED node",
     "dependencies": {
-        "@tensorflow/tfjs-node": "*",
+        "@tensorflow/tfjs-node": "1.4.0",
         "@tensorflow-models/coco-ssd": "*"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.ibm.com/va/node-red-tensorflowjs"
+        "url": "https://github.com/IBM/node-red-tensorflowjs"
     },
     "license": "Apache-2.0",
     "keywords": [


### PR DESCRIPTION
There aren't any tf 1.15 binaries available for the latest version of tfjs-node.
For now, just use the previous version (1.4.0) until we can get updated arm binaries.

Reference: #8 